### PR TITLE
fix credentials issues

### DIFF
--- a/sbt-version-policy/src/main/scala/sbtversionpolicy/SbtVersionPolicyMima.scala
+++ b/sbt-version-policy/src/main/scala/sbtversionpolicy/SbtVersionPolicyMima.scala
@@ -1,16 +1,13 @@
 package sbtversionpolicy
 
 import java.io.{File, FileWriter, PrintWriter}
-
 import scala.collection.JavaConverters.*
 import scala.io.Source
 import scala.util.Using
 import scala.util.control.NoStackTrace
-
-import sbt.{AutoPlugin, Def, Keys, file, settingKey, taskKey}
+import sbt.{AutoPlugin, Def, Keys, file, fileToRichFile, settingKey, taskKey}
 import sbt.librarymanagement.{CrossVersion, ModuleID}
 import sbt.librarymanagement.ivy.DirectCredentials
-
 import coursier.version.{Previous, Version, VersionCompatibility}
 import com.typesafe.tools.mima.plugin.MimaPlugin
 import MimaPlugin.autoImport.mimaPreviousArtifacts
@@ -115,11 +112,13 @@ object SbtVersionPolicyMima extends AutoPlugin {
   )
 
   override def buildSettings = Def.settings(
-    coursierCredentialsFile := file {
-      if (sys.props("os.name").toLowerCase.contains("mac"))
-        s"${sys.props("user.home")}/Library/Application Support/Coursier/credentials.properties"
-      else
-        s"${sys.props("user.home")}/.config/coursier/credentials.properties"
+    coursierCredentialsFile := {
+      file {
+        if (sys.props("os.name").toLowerCase.contains("mac"))
+          s"${sys.props("user.home")}/Library/Application Support/Coursier/credentials.properties"
+        else
+          s"${sys.props("user.home")}/.config/coursier/credentials.properties"
+      }
     },
   )
 

--- a/sbt-version-policy/src/main/scala/sbtversionpolicy/SbtVersionPolicyMima.scala
+++ b/sbt-version-policy/src/main/scala/sbtversionpolicy/SbtVersionPolicyMima.scala
@@ -1,10 +1,18 @@
 package sbtversionpolicy
 
+import java.io.{File, FileWriter, PrintWriter}
+
+import scala.collection.JavaConverters.*
+import scala.io.Source
+import scala.util.Using
+import scala.util.control.NoStackTrace
+
+import sbt.{AutoPlugin, Def, Keys, file, settingKey, taskKey}
+import sbt.librarymanagement.{CrossVersion, ModuleID}
+import sbt.librarymanagement.ivy.DirectCredentials
+
+import coursier.version.{Previous, Version, VersionCompatibility}
 import com.typesafe.tools.mima.plugin.MimaPlugin
-import coursier.version.{ Previous, Version, VersionCompatibility }
-import sbt.{AutoPlugin, Def, Keys, settingKey}
-import sbt.librarymanagement.{ CrossVersion, ModuleID }
-import scala.collection.JavaConverters._
 import MimaPlugin.autoImport.mimaPreviousArtifacts
 
 object SbtVersionPolicyMima extends AutoPlugin {
@@ -13,9 +21,13 @@ object SbtVersionPolicyMima extends AutoPlugin {
   override def requires = MimaPlugin
 
   object autoImport {
-    val versionPolicyPreviousVersions = settingKey[Seq[String]]("Previous versions to check compatibility against.")
+    val versionPolicyPreviousVersions = settingKey[Either[Throwable, Seq[String]]]("Previous versions to check compatibility against.")
+    val getVersionPolicyPreviousVersions = taskKey[Seq[String]]("Previous versions to check compatibility against.")
     val versionPolicyFirstVersion = settingKey[Option[String]]("First version this module was or will be published for.")
+    val coursierCredentialsFile = settingKey[File]("The coursier credentials file containing credentials for resolvers used in the project.")
+    val exportCredentialsToCoursier = taskKey[Unit]("Export credentials to a coursier credentials properties file")
   }
+
   val versionPolicyInternal: SbtVersionPolicyInternalKeys =
     new SbtVersionPolicyInternalKeys {}
 
@@ -24,14 +36,16 @@ object SbtVersionPolicyMima extends AutoPlugin {
 
   private def moduleName(crossVersion: CrossVersion, sv: String, sbv: String, baseName: String): String =
     CrossVersion(crossVersion, sv, sbv).fold(baseName)(_(baseName))
+
   private def moduleName(m: ModuleID, sv: String, sbv: String): String =
     moduleName(m.crossVersion, sv, sbv, m.name)
 
-  private lazy val previousVersionsFromRepo = Def.setting {
+  private lazy val previousVersionsFromRepo = Def.setting[Either[Throwable, Seq[String]]] {
 
     val projId = Keys.projectID.value
     val sv = Keys.scalaVersion.value
     val sbv = Keys.scalaBinaryVersion.value
+    val log = Keys.sLog.value
     val name = moduleName(projId, sv, sbv)
 
     val ivyProps = sbtversionpolicy.internal.Resolvers.defaultIvyProperties(Keys.ivyPaths.value.ivyHome)
@@ -44,28 +58,54 @@ object SbtVersionPolicyMima extends AutoPlugin {
     // Can't reference Keys.fullResolvers, which is a task.
     // So we're using the usual default repositories from coursier here…
     val fullRepos = coursierapi.Repository.defaults().asScala ++ repos
+
+    val start = System.nanoTime()
+
     val res = coursierapi.Versions.create()
       .withRepositories(fullRepos: _*)
       .withModule(coursierapi.Module.of(projId.organization, name))
       .versions()
-    res.getMergedListings().getAvailable().asScala.toSeq
+
+    log.debug(s"It took ${(System.nanoTime() - start) / 1e6f} ms to get previous versions of $name:")
+    res.getListings.asScala.foreach {
+      case e =>
+        val repo = e.getKey
+        val versions = e.getValue.toString
+        log.debug(s"  $repo: $versions")
+    }
+
+    val errors = res.getErrors.asScala.collect {
+      case e if !e.getValue.contains("not found:") =>
+        e.getValue
+    }
+    if (errors.nonEmpty) {
+      val msg = errors
+        .map(err => s"  $err")
+        .mkString("Failed to get artifact metadata from some repositories. Please fix the issues and reload.\n", "\n", "")
+      log.error(msg)
+      Left(new RuntimeException(msg) with NoStackTrace)
+    } else {
+      Right(res.getMergedListings().getAvailable().asScala)
+    }
   }
 
-  private lazy val previousVersionOpt: Def.Initialize[Option[String]] = Def.settingDyn {
+  private lazy val previousVersionOpt: Def.Initialize[Either[Throwable, Option[String]]] = Def.settingDyn {
     val ver = sbt.Keys.version.value
     val compat = versionPolicyVersionCompatibility.value
     Previous.previousStableVersion(ver) match {
-      case Some(previousVersion) => Def.setting(Some(previousVersion))
+      case Some(previousVersion) => Def.setting(Right(Some(previousVersion)))
       case None =>
         val mini = Version(compat.minimumCompatibleVersion(ver))
         Def.setting {
           val current = Version(ver)
-          val previousVersions = previousVersionsFromRepo.value.map(v => Version(v))
-          val compatible = previousVersions.filter(v => mini.compareTo(v) <= 0 && v.compareTo(current) < 0)
-          if (compatible.isEmpty)
-            None
-          else
-            Some(compatible.max.repr)
+          previousVersionsFromRepo.value.map(_.map(Version(_))).map {
+            previousVersions =>
+              val compatible = previousVersions.filter(v => mini.compareTo(v) <= 0 && v.compareTo(current) < 0)
+              if (compatible.isEmpty)
+                None
+              else
+                Some(compatible.max.repr)
+          }
         }
     }
   }
@@ -74,9 +114,18 @@ object SbtVersionPolicyMima extends AutoPlugin {
     versionPolicyFirstVersion := None,
   )
 
+  override def buildSettings = Def.settings(
+    coursierCredentialsFile := file {
+      if (sys.props("os.name").toLowerCase.contains("mac"))
+        s"${sys.props("user.home")}/Library/Application Support/Coursier/credentials.properties"
+      else
+        s"${sys.props("user.home")}/.config/coursier/credentials.properties"
+    },
+  )
+
   override def projectSettings = Def.settings(
     versionPolicyVersionCompatibility := {
-      import VersionCompatibility.{ Always, Default, Strict }
+      import VersionCompatibility.{Always, Default, Strict}
       val schemeOpt = Keys.versionScheme.?.value.getOrElse(None)
       schemeOpt match {
         case Some(x) =>
@@ -91,7 +140,7 @@ object SbtVersionPolicyMima extends AutoPlugin {
     },
     versionPolicyPreviousVersions := {
       val firstOpt = versionPolicyFirstVersion.value
-      previousVersionOpt.value match {
+      previousVersionOpt.value.map {
         case Some(v) =>
           val firstVersionCheck = firstOpt.forall(first => Version(first).compareTo(Version(v)) <= 0)
           if (firstVersionCheck) Seq(v)
@@ -100,10 +149,16 @@ object SbtVersionPolicyMima extends AutoPlugin {
           Nil
       }
     },
+    getVersionPolicyPreviousVersions := {
+      versionPolicyPreviousVersions.value match {
+        case Left(err) => throw err
+        case Right(value) => value
+      }
+    },
 
     mimaPreviousArtifacts := {
       val projId = Keys.projectID.value.withExplicitArtifacts(Vector.empty)
-      val previousVersions0 = versionPolicyPreviousVersions.value
+      val previousVersions0 = versionPolicyPreviousVersions.value.getOrElse(Nil)
 
       previousVersions0.toSet.map { version =>
         projId
@@ -113,7 +168,42 @@ object SbtVersionPolicyMima extends AutoPlugin {
           }
           .withRevision(version)
       }
-    }
+    },
+
+    exportCredentialsToCoursier := {
+      val credentials = Keys.credentials.value
+      val credentialsFile = coursierCredentialsFile.value
+      val preamble = "# Created by SbtVersionPolicyMima plugin"
+      val log = Keys.streams.value.log
+
+      if (credentialsFile.exists()) {
+        Using(Source.fromFile(credentialsFile)) {
+          source =>
+            if (!source.getLines().buffered.headOption.contains(preamble)) {
+              val backup = File.createTempFile("credentials-backup-", ".properties", credentialsFile.getParentFile)
+              log.info(s"Backup coursier credentials file to ${backup}")
+              if (!credentialsFile.renameTo(backup)) {
+                throw new RuntimeException("Failed to backup coursier credentials file") with NoStackTrace
+              }
+            }
+        }.get
+      }
+
+      credentialsFile.getParentFile().mkdirs()
+
+      Using(new PrintWriter(new FileWriter(credentialsFile))) {
+        writer =>
+          writer.println(preamble)
+          credentials.zipWithIndex.collect {
+            case (c: DirectCredentials, i) =>
+              writer.println(s"$i.host=${c.host}")
+              writer.println(s"$i.realm=${c.realm}")
+              writer.println(s"$i.username=${c.userName}")
+              writer.println(s"$i.password=${c.passwd}")
+              writer.println()
+          }
+      }.get
+    },
   )
 
 }

--- a/sbt-version-policy/src/main/scala/sbtversionpolicy/SbtVersionPolicyMima.scala
+++ b/sbt-version-policy/src/main/scala/sbtversionpolicy/SbtVersionPolicyMima.scala
@@ -3,6 +3,7 @@ package sbtversionpolicy
 import scala.collection.JavaConverters.*
 import scala.util.control.NoStackTrace
 import sbt.{AutoPlugin, Def, Keys, settingKey, taskKey}
+import sbt.KeyRanks.Invisible
 import sbt.librarymanagement.{CrossVersion, ModuleID}
 import coursier.version.{Previous, Version, VersionCompatibility}
 import com.typesafe.tools.mima.plugin.MimaPlugin
@@ -15,8 +16,10 @@ object SbtVersionPolicyMima extends AutoPlugin {
 
   object autoImport {
     val versionPolicyPreviousVersions = settingKey[Either[Throwable, Seq[String]]]("Previous versions to check compatibility against.")
-    val getVersionPolicyPreviousVersions = taskKey[Seq[String]]("Previous versions to check compatibility against.")
     val versionPolicyFirstVersion = settingKey[Option[String]]("First version this module was or will be published for.")
+
+    private[sbtversionpolicy] val getVersionPolicyPreviousVersions =
+      taskKey[Seq[String]]("Get previous versions or throw the error if it failed to resolve at load time").withRank(Invisible)
   }
 
   val versionPolicyInternal: SbtVersionPolicyInternalKeys =

--- a/sbt-version-policy/src/main/scala/sbtversionpolicy/SbtVersionPolicySettings.scala
+++ b/sbt-version-policy/src/main/scala/sbtversionpolicy/SbtVersionPolicySettings.scala
@@ -180,7 +180,7 @@ object SbtVersionPolicySettings {
         versionPolicyIntention.?.value
           .getOrElse(throw new MessageOnlyException("Please set the key versionPolicyIntention to declare the compatibility you want to check"))
       val currentModule = projectID.value
-      val formattedPreviousVersions = formatVersions(versionPolicyPreviousVersions.value)
+      val formattedPreviousVersions = formatVersions(getVersionPolicyPreviousVersions.value)
 
       if (intention == Compatibility.None) {
         log.info(s"Not checking dependencies compatibility of module ${nameAndRevision(currentModule)} because versionPolicyIntention is set to 'Compatibility.None'")
@@ -326,11 +326,11 @@ object SbtVersionPolicySettings {
       Seq.empty[(ModuleID, (DependencyCheckReport, Seq[(IncompatibilityType, Problem)]))]
     })(
       Def.ifS[Seq[(ModuleID, (DependencyCheckReport, Seq[(IncompatibilityType, Problem)]))]](Def.task {
-        versionPolicyPreviousVersions.value.isEmpty
+        getVersionPolicyPreviousVersions.value.isEmpty
       })(Def.task {
         throw new MessageOnlyException("Unable to find compatibility issues because versionPolicyPreviousVersions is empty.")
       })(Def.task {
-        versionPolicyPreviousVersions.value
+        getVersionPolicyPreviousVersions.value
         val dependencyIssues = versionPolicyFindDependencyIssues.value
         val mimaIssues = versionPolicyFindMimaIssues.value
         assert(

--- a/sbt-version-policy/src/main/scala/sbtversionpolicy/withsbtrelease/ReleaseVersion.scala
+++ b/sbt-version-policy/src/main/scala/sbtversionpolicy/withsbtrelease/ReleaseVersion.scala
@@ -4,7 +4,7 @@ import sbtversionpolicy.Compatibility
 import sbtversionpolicy.SbtVersionPolicyPlugin.aggregatedAssessedCompatibilityWithLatestRelease
 import sbtversionpolicy.SbtVersionPolicyPlugin.autoImport.versionPolicyAssessCompatibility
 import sbt.*
-import sbtversionpolicy.SbtVersionPolicyMima.autoImport.versionPolicyPreviousVersions
+import sbtversionpolicy.SbtVersionPolicyMima.autoImport.getVersionPolicyPreviousVersions
 
 /** Convenient methods to integrate with the plugin sbt-release */
 object ReleaseVersion {
@@ -41,7 +41,7 @@ object ReleaseVersion {
 
   private def fromAssessedCompatibility(qualifier: String)(assessCompatibility: Def.Initialize[Task[Compatibility]]): Def.Initialize[Task[String => String]] =
     Def.ifS(Def.task {
-      versionPolicyPreviousVersions.value.isEmpty
+      getVersionPolicyPreviousVersions.value.isEmpty
     })(Def.task {
       // If there are no previous versions to assess the compatibility with,
       // fallback to the default release version function, which drops the qualifier

--- a/sbt-version-policy/src/sbt-test/sbt-version-policy/first-version/build.sbt
+++ b/sbt-version-policy/src/sbt-test/sbt-version-policy/first-version/build.sbt
@@ -4,7 +4,7 @@ lazy val a = project
     version := "0.1.1-SNAPSHOT",
     versionPolicyFirstVersion := Some("0.1.1"),
     check := {
-      val prev = versionPolicyPreviousVersions.value
+      val prev = versionPolicyPreviousVersions.value.right.get
       val expected = Seq()
       assert(prev == expected, s"prev=$prev, expected=$expected")
     }
@@ -15,7 +15,7 @@ lazy val b = project
     version := "0.1.1-SNAPSHOT",
     versionPolicyFirstVersion := Some("0.1.0"),
     check := {
-      val prev = versionPolicyPreviousVersions.value
+      val prev = versionPolicyPreviousVersions.value.right.get
       val expected = Seq("0.1.0")
       assert(prev == expected, s"prev=$prev, expected=$expected")
     }


### PR DESCRIPTION
ticket: https://app.shortcut.com/tubi/story/738427/fix-credentials-issues-of-sbt-version-policy

It is not possible to use `sbt.Keys.credentials` directly, because it's a task key, but `versionPolicyPreviousVersions` is a setting key. So the `exportCredentialsToCoursier` task is added as a workaround. The workflow would be
1. export sbt credentials to the default [credentials file for coursier](https://get-coursier.io/docs/other-credentials#property-file) using `sbt exportCredentialsToCoursier`
2. reload the project and run the version policy check
